### PR TITLE
17 fix python path

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,5 +95,6 @@ A sub directory of that directory will be created with the name `LaTeX2AI` which
 
 # Changelog
 - **Pre-release**
-    - Nothing yet
+  - Bug fixes:
+    - Replace hardcoded path to python executable with environment variable `PYTHON_EXE`
 - **v0.0.1:** Initial release

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Both files have to be copied into the same directory and this directory has to b
 To build LaTeX2AI from source additional requirements have to be met:
 - A C++ compiler has to be available on the system. This repository includes a Visual Studio 2017 solution for Windows.
 - `python3` and `git` have to be available on the system.
+- An environment variable `PYTHON_EXE` has to be defined which points to a valid `python3` executable on the system.
 
 ### Getting started
 1. Download and unpack the [Adobe Illustrator CS6 SDK](http://download.macromedia.com/pub/developer/illustrator/sdk/AI_CS6_SDK_Win_682.6.1.zip).

--- a/forms/LaTeX2AIForms.csproj
+++ b/forms/LaTeX2AIForms.csproj
@@ -151,6 +151,6 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PreBuildEvent>C:\Users\VirtualBox\Anaconda3\python.exe "$(ProjectDir)..\scripts\create_headers.py" cs</PreBuildEvent>
+    <PreBuildEvent>$(PYTHON_EXE) "$(ProjectDir)..\scripts\create_headers.py" cs</PreBuildEvent>
   </PropertyGroup>
 </Project>

--- a/l2a/LaTeX2AI.vcxproj
+++ b/l2a/LaTeX2AI.vcxproj
@@ -151,7 +151,7 @@
       <LargeAddressAware>true</LargeAddressAware>
     </Link>
     <PreBuildEvent>
-      <Command>C:\Users\VirtualBox\Anaconda3\python.exe "$(ProjectDir)..\scripts\create_headers.py" cpp</Command>
+      <Command>$(PYTHON_EXE) "$(ProjectDir)..\scripts\create_headers.py" cpp</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -210,7 +210,7 @@
       <LargeAddressAware>true</LargeAddressAware>
     </Link>
     <PreBuildEvent>
-      <Command>C:\Users\VirtualBox\Anaconda3\python.exe "$(ProjectDir)..\scripts\create_headers.py" cpp</Command>
+      <Command>$(PYTHON_EXE) "$(ProjectDir)..\scripts\create_headers.py" cpp</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -269,7 +269,7 @@
       <LargeAddressAware>true</LargeAddressAware>
     </Link>
     <PreBuildEvent>
-      <Command>C:\Users\VirtualBox\Anaconda3\python.exe "$(ProjectDir)..\scripts\create_headers.py" cpp</Command>
+      <Command>$(PYTHON_EXE) "$(ProjectDir)..\scripts\create_headers.py" cpp</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -328,7 +328,7 @@
       <LargeAddressAware>true</LargeAddressAware>
     </Link>
     <PreBuildEvent>
-      <Command>C:\Users\VirtualBox\Anaconda3\python.exe "$(ProjectDir)..\scripts\create_headers.py" cpp</Command>
+      <Command>$(PYTHON_EXE) "$(ProjectDir)..\scripts\create_headers.py" cpp</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
Add an environment variable `PYTHON_EXE` for the pre-build scripts.

See #17.