### PR TITLE
14 resolve header input

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ It is generally advisable to redo all boundary boxes before exporting the Illust
 ## File structure
 LaTeX2AI requires a certain file structure.
 It is assumed that all Illustrator files in the same directory use the same LaTeX header `LaTeX2AI_header.tex` (if no one exits in the directory, it will be created the first time it is needed).
-This header can be edited to include packages and macros needed for the labels.
+This header can be edited to include packages and macros needed for the labels (LaTeX2AI supports `\input` commands in the header, also recursively).
 A sub directory of that directory will be created with the name `LaTeX2AI` which stores the `.pdf` files for the labels of all Illustrator documents in that directory.
 
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ A sub directory of that directory will be created with the name `LaTeX2AI` which
 
 # Changelog
 - **Pre-release**
+  - New features:
+    - Allow for `input` commands in LaTeX headers.
   - Bug fixes:
     - Replace hardcoded path to python executable with environment variable `PYTHON_EXE`
 - **v0.0.1:** Initial release

--- a/l2a/src/l2a_latex/l2a_latex.cpp
+++ b/l2a/src/l2a_latex/l2a_latex.cpp
@@ -317,8 +317,9 @@ ai::FilePath L2A::LATEX::WriteLatexFiles(const ai::UnicodeString& latex_code, co
     tex_file.AddComponent(ai::UnicodeString(L2A::NAMES::create_pdf_tex_name_));
     batch_file.AddComponent(ai::UnicodeString(L2A::NAMES::create_pdf_batch_name_));
 
-    // Copy the header into the temp directory.
-    L2A::UTIL::CopyFileL2A(GetHeaderPath(), tex_header_file);
+    // Create the header in the temp directory.
+    ai::UnicodeString header_string = L2A::LATEX::GetHeaderWithIncludedInputs(GetHeaderPath());
+    L2A::UTIL::WriteFileUTF8(tex_header_file, header_string, true);
 
     // Creates the LaTeX file.
     L2A::UTIL::WriteFileUTF8(tex_file, GetLatexString(latex_code), true);

--- a/l2a/src/l2a_latex/l2a_latex.cpp
+++ b/l2a/src/l2a_latex/l2a_latex.cpp
@@ -389,7 +389,7 @@ ai::UnicodeString L2A::LATEX::GetHeaderWithIncludedInputs(const ai::FilePath& he
     auto input_begin = std::sregex_iterator(header_string.begin(), header_string.end(), re_input);
     auto input_end = std::sregex_iterator();
     std::string return_header("");
-    int last_pos = 0;
+    long long int last_pos = 0;
     for (std::sregex_iterator i = input_begin; i != input_end; ++i)
     {
         std::smatch match = *i;

--- a/l2a/src/l2a_latex/l2a_latex.h
+++ b/l2a/src/l2a_latex/l2a_latex.h
@@ -111,6 +111,11 @@ namespace L2A
          * \brief Get the license information for tex files.
          */
         ai::UnicodeString GetTexLicense();
+
+        /**
+         * \brief Get the header as a string, wehre all inputs are resoved.
+         */
+        ai::UnicodeString GetHeaderWithIncludedInputs(const ai::FilePath& header_path);
     }  // namespace LATEX
 }  // namespace L2A
 


### PR DESCRIPTION
Allow for `\input` commands in LaTeX headers.

Closes #14 