### PR TITLE
Clarify build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ The following software has to be installed on the system:
 ## Install LaTeX2AI
 Install LaTeX2AI from rebuild binaries can be downloaded from the [GitHub release page](https://github.com/stoani89/LaTeX2AI/releases).
 They consist of two files `LaTeX2AI.aip` and `LaTeX2AIForms.exe`.
-Both files have to be copied into the same directory and this directory has to be set as the Adobe Illustrator Plugin directory.
+There are two ways to add LaTeX2AI to Illustrator:
+- Both files can be copied to the default plug-in directory `C:\Program Files\Adobe\Adobe Illustrator <your version number>\Plug-ins`, preferably into a subdirectory `LaTeX2AI` (for this method administrator privileges are required).
+- Both files can be copied into an arbitrary directory and this directory has to be set as the Adobe Illustrator Plugin directory.
 
 ## Build LaTeX2AI from source
 
@@ -31,6 +33,10 @@ To build LaTeX2AI from source additional requirements have to be met:
 	git submodule update --init
 	```
 1. Open `Adobe Illustrator CS6 SDK/sample code/LaTeX2AI/LaTeX2AI.sln` with Visual Studio and compile the solution.
+1. The compiled binaries are located unter `Adobe Illustrator CS6 SDK/sample code/output/win/x64/<Debug/Release>`.
+   This directory has to be set as the Plugin directory in Illustrator.
+   The relevant files created, i.e. the ones needed to run LaTeX2AI are `LaTeX2AI.aip` and `LaTeX2AIForms.exe`.
+   The executable `LaTeX2AIForms.exe` contains the UI for LaTeX2AI and should only be called from within the plugin itself.
 
 
 # How to use LaTeX2AI
@@ -113,4 +119,6 @@ For example:
     - Replace hardcoded path to python executable with environment variable `PYTHON_EXE`
   - Other:
     - Add information how to cite.
+    - Forms and the plugin are now compiled in the same directory, also add more detailed build information.
+    - LaTeX2AI can now also be installed in the default Illustrator plug-in directory.
 - **v0.0.1:** Initial release

--- a/forms/LaTeX2AIForms.csproj
+++ b/forms/LaTeX2AIForms.csproj
@@ -33,19 +33,21 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>..\..\output\forms\Debug\</OutputPath>
+    <OutputPath>..\..\output\win\x64\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>..\..\output\forms\Release\</OutputPath>
+    <OutputPath>..\..\output\win\x64\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/l2a/src/utility/file_system.cpp
+++ b/l2a/src/utility/file_system.cpp
@@ -367,28 +367,39 @@ ai::UnicodeString L2A::UTIL::GetGhostScriptCommand()
 ai::FilePath L2A::UTIL::GetFormsPath()
 {
     // Default value.
-    ai::FilePath forms_path(ai::UnicodeString(""));
+    std::vector<ai::FilePath> forms_paths;
 
-    // Get the path to the plug in.
-    ai::FilePath plugin_directory;
-    sAIFolders->FindFolder(kAIAdditionalAIPluginsFolderType, false, plugin_directory);
-    if (L2A::UTIL::IsDirectory(plugin_directory))
+    // Look in the installed plugins folder as well as the additional extensions folder.
+    std::vector<ai::FilePath> plugin_directories(2);
+    sAIFolders->FindFolder(kAIPluginsFolderType, false, plugin_directories[0]);
+    sAIFolders->FindFolder(kAIAdditionalAIPluginsFolderType, false, plugin_directories[1]);
+    for (const auto& plugin_directory : plugin_directories)
     {
-        // Search for the executable in the folder.
-        for (const auto& item :
-            std::filesystem::recursive_directory_iterator(plugin_directory.GetFullPath().as_Platform()))
+        if (L2A::UTIL::IsDirectory(plugin_directory))
         {
-            ai::FilePath current_item(ai::UnicodeString(item.path()));
-            if (current_item.GetFileName() == "LaTeX2AIForms.exe")
+            // Search for the executable in the folder.
+            for (const auto& item :
+                std::filesystem::recursive_directory_iterator(plugin_directory.GetFullPath().as_Platform()))
             {
-                forms_path = current_item;
-                break;
+                ai::FilePath current_item(ai::UnicodeString(item.path()));
+                if (current_item.GetFileName() == "LaTeX2AIForms.exe") forms_paths.push_back(current_item);
             }
         }
     }
 
-    // Return the path.
-    return forms_path;
+    if (forms_paths.size() > 1)
+    {
+        // More than one found forms executable could lead to undefined behaviour.
+        ai::UnicodeString error_string("LaTeX2AI found more than one LaTeX2AIForms.exe executable.");
+        error_string += "\nThere should only be one.";
+        error_string += "\nThe found paths are:";
+        for (const auto& forms_exe : forms_paths) error_string += "\n" + forms_exe.GetFullPath();
+        l2a_error(error_string);
+    }
+    else if (forms_paths.size() == 1)
+        return forms_paths[0];
+    else
+        return ai::FilePath(ai::UnicodeString(""));
 }
 
 /**


### PR DESCRIPTION
Allow LaTeX2AI to be installed in the default Illustrator Plug-in directory. Also clarify the build instructions and unify the binary output folder.